### PR TITLE
Feat feedback invert

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "shelly-http",
 	"shortname": "shelly",
 	"description": "shelly",
-	"version": "0.0.0",
+	"version": "0.1.1",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-shelly-http.git",
 	"bugs": "https://github.com/bitfocus/companion-module-shelly-http/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shelly-relay",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {
@@ -12,7 +12,7 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@companion-module/base": "~1.4.1",
+		"@companion-module/base": "~1.5.0",
 		"got": "^12.6.0"
 	},
 	"devDependencies": {

--- a/shellyProducts/shelly1.js
+++ b/shellyProducts/shelly1.js
@@ -54,22 +54,9 @@ class Shelly1 extends ShellyMaster {
             type: 'boolean',
             name: 'Relay State',
             description: "Change the button based on the current Shelly relay state",
-            options: [
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
-                }
-            ],
+            options: [],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(this.lastStatus);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-
-                return currentRelayState;
+                return this.getRelayState(this.lastStatus);
             }
         }
 

--- a/shellyProducts/shelly25.js
+++ b/shellyProducts/shelly25.js
@@ -223,21 +223,10 @@ class Shelly25Relay extends ShellyMaster {
                         { id: 0, label: "Relay 1" },
                         { id: 1, label: "Relay 2" },
                     ],
-                },
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
                 }
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedRelay);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedRelay);
             }
         },
         powerConsumption: {

--- a/shellyProducts/shellyDimmer.js
+++ b/shellyProducts/shellyDimmer.js
@@ -126,21 +126,9 @@ class ShellyDimmer extends ShellyMaster {
             type: 'boolean',
             name: 'Relay State',
             description: "Change the button based on the current Shelly relay state",
-            options: [
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
-                }
-            ],
+            options: [],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState();
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState();
             }
         },
         dimValue: {

--- a/shellyProducts/shellyPlus1.js
+++ b/shellyProducts/shellyPlus1.js
@@ -53,21 +53,9 @@ class ShellyPlus1 extends ShellyMaster {
             type: 'boolean',
             name: 'Relay State',
             description: "Change the button based on the current Shelly relay state",
-            options: [
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
-                }
-            ],
+            options: [],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState();
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState();
             }
         }
     }

--- a/shellyProducts/shellyPlus2PM.js
+++ b/shellyProducts/shellyPlus2PM.js
@@ -236,11 +236,7 @@ class ShellyPlus2PMRelay extends ShellyMaster {
                 }
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedRelay);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedRelay);
             }
         },
         powerConsumption: {

--- a/shellyProducts/shellyPro2.js
+++ b/shellyProducts/shellyPro2.js
@@ -98,21 +98,10 @@ class ShellyPro2 extends ShellyMaster {
                         { id: 0, label: "Relay 1" },
                         { id: 1, label: "Relay 2" },
                     ],
-                },
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
                 }
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedRelay);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedRelay);
             }
         }
     }

--- a/shellyProducts/shellyPro3.js
+++ b/shellyProducts/shellyPro3.js
@@ -104,22 +104,10 @@ class ShellyPro3 extends ShellyMaster {
                         { id: 1, label: "Relay 2" },
                         { id: 2, label: "Relay 3" },
                     ],
-                },
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
                 }
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedRelay);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedRelay);
             }
         }
     }

--- a/shellyProducts/shellyPro4PM.js
+++ b/shellyProducts/shellyPro4PM.js
@@ -118,21 +118,10 @@ class ShellyPro4PM extends ShellyMaster {
                         { id: 2, label: "Relay 3" },
                         { id: 3, label: "Relay 4" },
                     ],
-                },
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
                 }
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedRelay);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedRelay);
             }
         },
         powerConsumption: {

--- a/shellyProducts/shellyRGBW2.js
+++ b/shellyProducts/shellyRGBW2.js
@@ -141,21 +141,9 @@ class ShellyRGBW2Color extends ShellyMaster {
             type: 'boolean',
             name: 'Relay State',
             description: "Change the button based on the current Shelly relay state",
-            options: [
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
-                }
-            ],
+            options: [],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState();
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState();
             }
         },
         dimValue: {
@@ -340,22 +328,11 @@ class ShellyRGBW2White extends ShellyMaster {
                         { id: 2, label: "Channel 3" },
                         { id: 3, label: "Channel 4" },
                     ],
-                },
-                {
-                    type: 'checkbox',
-                    label: 'Invert',
-                    tooltip: 'If checked, this feedback gets enabled when the relay is off',
-                    id: 'invertRelayState',
-                    default: false
-                },
+                }
 
             ],
             callback: async (feedback, context) => {
-                var currentRelayState = this.getRelayState(feedback.options.selectedChannel);
-                if (feedback.options.invertRelayState == true) {
-                    currentRelayState = !currentRelayState;
-                }
-                return currentRelayState;
+                return this.getRelayState(feedback.options.selectedChannel);
             }
         },
         dimValue: {

--- a/upgrade.js
+++ b/upgrade.js
@@ -1,3 +1,18 @@
 export const upgradeScripts = [
+    function removeOldInvertFeedbackScripts(context, props) {
+        var result = {};
+        result.updatedFeedbacks = [];
+        for (const feedback of props.feedbacks) {
+            if (feedback.options['invertRelayState'] !== undefined) {
+                feedback.isInverted = !!feedback.options['invertRelayState']
+                delete feedback.options['invertRelayState']
+                result.updatedFeedbacks.push(feedback)
+            }
+        }
 
+        result.updatedActions = [];
+        result.updatedConfig = null;
+        
+        return result;
+    },
 ]


### PR DESCRIPTION
Remove the invert options in the feedback definitions so the new native invertion feature for boolean feedbacks can be used.